### PR TITLE
Add small delay into the line follower example

### DIFF
--- a/warduino/guide/open-bot-brain.md
+++ b/warduino/guide/open-bot-brain.md
@@ -225,6 +225,7 @@ export function main(): void { // [!code focus:19]
             driveMotor(OutputPort.port1, 0);
             driveMotor(OutputPort.port2, 5000);
         }
+        delay(5);
     }
 }
 ```


### PR DESCRIPTION
This delay is needed for the debugger thread to read in new messages and for the color sensor to stay alive.

Maybe we should do something in WARDuino to fix this, for example, let the debug thread read some messages if it hasn't done so in a certain amount of time event without delays.